### PR TITLE
Unconditionally add ExceptT instances using transformers-compat

### DIFF
--- a/Control/Monad/Exception.hs
+++ b/Control/Monad/Exception.hs
@@ -53,11 +53,9 @@ import Control.Monad.Trans.Error (Error(..),
                                   ErrorT(..),
                                   mapErrorT,
                                   runErrorT)
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except (ExceptT(..),
                                    mapExceptT,
                                    runExceptT)
-#endif /* MIN_VERSION_transformers(0,4,0) */
 import Control.Monad.Trans.Identity (IdentityT(..),
                                      mapIdentityT,
                                      runIdentityT)
@@ -303,7 +301,6 @@ instance (MonadException m, Error e) =>
     act `finally` sequel =
         mapErrorT (\act' -> act' `finally` runErrorT sequel) act
 
-#if MIN_VERSION_transformers(0,4,0)
 instance (MonadException m) =>
     MonadException (ExceptT e' m) where
     throw       = lift . throw
@@ -311,7 +308,6 @@ instance (MonadException m) =>
 
     act `finally` sequel =
         mapExceptT (\act' -> act' `finally` runExceptT sequel) act
-#endif /* MIN_VERSION_transformers(0,4,0) */
 
 instance (MonadException m) =>
     MonadException (IdentityT m) where
@@ -382,12 +378,10 @@ instance (MonadAsyncException m, Error e) =>
     mask act = ErrorT $ mask $ \restore ->
                runErrorT $ act (mapErrorT restore)
 
-#if MIN_VERSION_transformers(0,4,0)
 instance (MonadAsyncException m) =>
     MonadAsyncException (ExceptT e' m) where
     mask act = ExceptT $ mask $ \restore ->
                runExceptT $ act (mapExceptT restore)
-#endif /* MIN_VERSION_transformers(0,4,0) */
 
 instance (MonadAsyncException m) =>
     MonadAsyncException (IdentityT m) where

--- a/exception-transformers.cabal
+++ b/exception-transformers.cabal
@@ -25,9 +25,10 @@ library
     Control.Monad.Exception
 
   build-depends:
-    base         >= 4   && < 5,
-    stm          >= 2.1 && < 2.5,
-    transformers >= 0.2 && < 0.5
+    base                >= 4   && < 5,
+    stm                 >= 2.1 && < 2.5,
+    transformers        >= 0.2 && < 0.5,
+    transformers-compat >= 0.3 && < 0.4
 
   ghc-options:
     -Wall
@@ -44,7 +45,8 @@ test-suite unit
     exception-transformers >= 0.3 && < 0.5,
     test-framework         >= 0.8 && < 0.9,
     test-framework-hunit   >= 0.3 && < 0.4,
-    transformers           >= 0.2 && < 0.5
+    transformers           >= 0.2 && < 0.5,
+    transformers-compat    >= 0.3 && < 0.4
 
   ghc-options:
     -Wall

--- a/exception-transformers.cabal
+++ b/exception-transformers.cabal
@@ -46,7 +46,7 @@ test-suite unit
     test-framework         >= 0.8 && < 0.9,
     test-framework-hunit   >= 0.3 && < 0.4,
     transformers           >= 0.2 && < 0.5,
-    transformers-compat    >= 0.3 && < 0.4
+    transformers-compat    >= 0.3 && < 0.5
 
   ghc-options:
     -Wall

--- a/tests/unit/Main.hs
+++ b/tests/unit/Main.hs
@@ -16,9 +16,7 @@ import Prelude hiding (catch)
 
 import Control.Monad.Exception
 import Control.Monad.Trans.Error
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except
-#endif /* MIN_VERSION_transformers(0,4,0) */
 import Control.Monad.IO.Class
 import Data.IORef
 import Test.Framework
@@ -61,7 +59,6 @@ errorTests = testGroup "ErrorT tests"
 
 exceptTests :: Test
 exceptTests = testGroup "ExceptT tests"
-#if MIN_VERSION_transformers(0,4,0)
     [testCase (conl ++ " " ++ whatl) (mkExceptTest con what) | (conl, con) <- cons, (whatl, what) <- whats]
   where
     whats :: [(String, ExceptT String IO ())]
@@ -85,6 +82,3 @@ exceptTests = testGroup "ExceptT tests"
       where
         expected :: String
         expected = "sequel called"
-#else /* !MIN_VERSION_transformers(0,4,0) */
-    []
-#endif /* !MIN_VERSION_transformers(0,4,0) */


### PR DESCRIPTION
This is needed to allow reverse-dependencies of this package to migrate to `ExceptT` while keeping backwards compatibility for older versions of `transformers`.

Also see https://github.com/fpco/stackage/issues/439
